### PR TITLE
Fixed bugs in Mirror of Duality (c511000481)

### DIFF
--- a/script/unofficial/c511000481.lua
+++ b/script/unofficial/c511000481.lua
@@ -14,15 +14,15 @@ function s.initial_effect(c)
 	c:RegisterEffect(e1)
 end
 function s.target(e,tp,eg,ep,ev,re,r,rp,chk)
-	if chk==0 then return Duel.IsExistingMatchingCard(aux.TRUE,tp,LOCATION,LOCATION_MZONE,1,nil) end
-	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION,LOCATION_MZONE,nil)
+	if chk==0 then return Duel.GetFieldGroupCount(tp,LOCATION_MZONE,LOCATION_MZONE)>0 end
+        local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	Duel.SetOperationInfo(0,CATEGORY_DESTROY,g,#g,0,0)
 	Duel.SetOperationInfo(0,CATEGORY_DAMAGE,nil,0,1-tp,#g*500)
 end
 function s.activate(e,tp,eg,ep,ev,re,r,rp)
-	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION,LOCATION_MZONE,nil)
+	local g=Duel.GetMatchingGroup(aux.TRUE,tp,LOCATION_MZONE,LOCATION_MZONE,nil)
 	if #g>0 then
 		local ct=Duel.Destroy(g,REASON_EFFECT)
-		Duel.Damage(1-tp,ct*500,REASON_EFFECT,true)
+		Duel.Damage(1-tp,ct*500,REASON_EFFECT)
 	end
 end


### PR DESCRIPTION
1. Clear redundant check with 'IsExistingMatchingCard'.
2. Fix Location check (it was misworded).
3. Removed the unnecessary Value that failed the Damage part.